### PR TITLE
Standalone Search

### DIFF
--- a/DivingBoard/DivingBoard.swift
+++ b/DivingBoard/DivingBoard.swift
@@ -49,6 +49,26 @@ public class DivingBoard {
         return navController
     }
     
+    /**
+     Retriece ViewController for searching a photo from Unsplash.
+     
+     - Parameter clientID: Your Unsplash app ID.
+     - Parameter presentingViewController: The UIViewController that you are presenting from,
+     which gets set as the delegate. (Make sure your presenting view controller conforms to
+     UnsplashPickerDelegate).
+     
+     - Returns: The view controller to present.
+     */
+    public static func unsplashSearch(withClientID clientID: String, presentingViewController: UIViewController) -> UICollectionViewController {
+        let storyboard = UIStoryboard.init(name: "Main", bundle: Bundle(for: self))
+        let view = storyboard.instantiateViewController(withIdentifier: "PhotoCollectionViewController") as! PhotoCollectionViewController
+        view.delegate = presentingViewController as? UnsplashPickerDelegate
+        view.clientID = clientID
+        view.collectionType = .search
+        view.currentLayoutStyle = .grid
+        return view
+    }
+    
     // MARK: - Public utilities
     
     /**

--- a/DivingBoard/PhotoCollectionViewController.swift
+++ b/DivingBoard/PhotoCollectionViewController.swift
@@ -80,6 +80,7 @@ class PhotoCollectionViewController: UICollectionViewController {
         // adjust insets to make room for the collectionTypePickerView
         collectionView?.contentInset.top += topInsetAdjustment
         collectionView?.scrollIndicatorInsets.top += topInsetAdjustment
+        collectionView?.backgroundColor = .white
         
         if collectionType == .search {
             configureToShowSearchBar()


### PR DESCRIPTION
This add the ability for the developer to only present the search controller to the user.

```swift
func showSearch(){
    let unsplashPicker = DivingBoard.unsplashSearch(withClientID: unsplashAppID, presentingViewController: self)
    present(unsplashPicker, animated: true, completion: nil)
}
```