### PR TITLE
Add Placeholder for SearchBar

### DIFF
--- a/DivingBoard/PhotoCollectionViewController+Search.swift
+++ b/DivingBoard/PhotoCollectionViewController+Search.swift
@@ -34,7 +34,7 @@ class CollectionReusableSearchView: UICollectionReusableView {
         searchBar.autoresizingMask = [.flexibleWidth]
         searchBar.backgroundImage = UIImage()
         searchBar.backgroundColor = commonBarColor
-	searchBar.placeholder = "Search"
+        searchBar.placeholder = "Search"
         addSubview(searchBar)
     }
 }

--- a/DivingBoard/PhotoCollectionViewController+Search.swift
+++ b/DivingBoard/PhotoCollectionViewController+Search.swift
@@ -34,6 +34,7 @@ class CollectionReusableSearchView: UICollectionReusableView {
         searchBar.autoresizingMask = [.flexibleWidth]
         searchBar.backgroundImage = UIImage()
         searchBar.backgroundColor = commonBarColor
+	searchBar.placeholder = "Search"
         addSubview(searchBar)
     }
 }


### PR DESCRIPTION
The screen is pretty empty if you don't specify a initial search term. This should help point users to the SearchBar quicker.

![image](https://user-images.githubusercontent.com/197010/43996482-60148074-9d91-11e8-9f1c-f6c45c6509b3.png)
